### PR TITLE
added extra bit for full similarity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
  	<dependency>
 		<groupId>gov.nih.ncats</groupId>
 		<artifactId>molwitch-cdk</artifactId>
-		<version>1.0.9-SNAPSHOT</version>
+		<version>1.0.9</version>
 		<scope>test</scope>
 	</dependency>
 	<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>structure-indexer</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.13-SNAPSHOT</version>
+  <version>0.0.14-SNAPSHOT</version>
   <name>structure-indexer</name>
   <url>https://github.com/ncats/structure-indexer</url>
 
@@ -121,20 +121,6 @@
 		<version>2.7.1</version>
 		<scope>test</scope>
 	</dependency>
-
-<!-- 	<dependency> -->
-<!-- 		<groupId>gov.nih.ncats</groupId> -->
-<!-- 		<artifactId>molwitch-jchem3</artifactId> -->
-<!-- 		<version>1.0.9</version> -->
-<!-- 		<scope>test</scope> -->
-<!-- 	</dependency> -->
-<!-- 	<dependency> -->
-<!-- 		<groupId>chemaxon</groupId> -->
-<!-- 		<artifactId>jchem</artifactId> -->
-<!-- 		<version>1.0.0fake</version> -->
-<!-- 		<scope>provided</scope> -->
-<!-- 	</dependency> -->
-	
   </dependencies>
 
   <build>
@@ -147,35 +133,6 @@
           <target>1.8</target>
         </configuration>
       </plugin>
-      
-     <!--&lt;!&ndash;  <plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-shade-plugin</artifactId>-->
-        <!--<version>3.0.0</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<phase>package</phase>-->
-            <!--<goals>-->
-              <!--<goal>shade</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
-        <!--&lt;!&ndash; This configuration removes manifest signature files-->
-        <!--which if we keep in will cause problems since jchem (?) is signed &ndash;&gt;-->
-        <!--<configuration>-->
-         <!--<filters>-->
-        <!--<filter>-->
-            <!--<artifact>*:*</artifact>-->
-            <!--<excludes>-->
-                <!--<exclude>META-INF/*.SF</exclude>-->
-                <!--<exclude>META-INF/*.DSA</exclude>-->
-                <!--<exclude>META-INF/*.RSA</exclude>-->
-            <!--</excludes>-->
-        <!--</filter>-->
-    <!--</filters>-->
-        <!---->
-        <!--</configuration>-->
-      <!--</plugin>&ndash;&gt;-->
       </plugins>
   </build>
 

--- a/src/main/java/gov/nih/ncats/structureIndexer/ECFingerprint.java
+++ b/src/main/java/gov/nih/ncats/structureIndexer/ECFingerprint.java
@@ -16,125 +16,116 @@ import gov.nih.ncats.molwitch.Chemical;
 
 
 
-class ECFingerprint{
-	int nBits;
-	int MAX_LENGTH=8;
-	int BITS_PER_STRING=1;
-	Map<Integer,HashMap<Integer,Boolean>> FPbit = new HashMap<Integer,HashMap<Integer,Boolean>>();
-	ArrayList<Integer> onBits = new ArrayList<Integer>();
-	Stack<Atom> atomStack= new Stack<Atom>();
-	Stack<Integer> bondStack= new Stack<Integer>();
-	Stack<String> descriptor= new Stack<String>();
-	
-	public ECFingerprint(int nBits, int MAX_LENGTH, int BITS_PER_STRING){
-		this.nBits=nBits;
-		this.MAX_LENGTH=MAX_LENGTH;
-		this.BITS_PER_STRING=BITS_PER_STRING;
-	}
-	public long[] getFingerprint(Chemical c){
-		return myFingerprint(c,nBits);
-	}
-	private void AssignMap(Chemical c){
-		int i=1;
-		
-		for(Atom a:c.getAtoms()){
-			a.setAtomToAtomMap(i);
-			i++;
-		}
-	}
-	public void unAssignMap(Chemical c){
-		for(Atom a:c.getAtoms()){
-			a.setAtomToAtomMap(0);
-		}
-	}
-	//MY STUFF ... kinda dumb
-	private long[] myFingerprint(Chemical c,int nBits){
-		c.makeHydrogensImplicit();
-		FPbit = new HashMap<Integer,HashMap<Integer,Boolean>>();
-		onBits = new ArrayList<Integer>();
-		ArrayList<Atom> atomList = new ArrayList<Atom>();
-		ArrayList<Atom> visitedAtoms = new ArrayList<Atom>();
-		ArrayList<Atom> cRing = new ArrayList<Atom>();
-				
-		AssignMap(c);
-		for(Atom atom : c.getAtoms()){
-			atomList = new ArrayList<Atom>();
-			visitedAtoms = new ArrayList<Atom>();
-			atomList.add(atom);
-			String desc=atom.getSymbol();
-			int depth=0;
-			this.addDescriptor(desc);
-			while(depth<MAX_LENGTH){
-				visitedAtoms.addAll(atomList);	
-				for(Atom gAtom : atomList){
-					for(Atom nAtom : gAtom.getNeighbors()){
-						if(!visitedAtoms.contains(nAtom))
-							cRing.add(nAtom);
-					}
-				}
-				if(cRing.size()<=0)break;
-				Collections.sort(cRing, new Comparator<Atom>(){
-					@Override
-					public int compare(Atom arg0, Atom arg1) {
-						return asString(arg0).compareTo(asString(arg1));
-					}});
-				desc+="(" +makeSTR(cRing) + ")";
-				atomList=cRing;
-				cRing = new ArrayList<Atom>();	
-				depth++;
-				this.addDescriptor(desc);
-			}	
-		}
-	
-		long[] fprints= new long[nBits/64];
-		for(int i:onBits){
-			fprints[i/64]=fprints[i/64]|(1<<i%64);
-		}
-		unAssignMap(c);
-		return fprints;
-	}
-	private String asString(Atom ca){
-	    
-		return ca.getSymbol() + ca.getImplicitHCount();
-	}
-	private String makeSTR(List<Atom> cList){
-		String ret="";
-		for(Atom ca: cList){
-			ret+=asString(ca);
-		}
-		return ret;
-	}
-	private void addDescriptor(String s){
-		//System.out.println(s);
-		for(int i=0;i<BITS_PER_STRING;i++){
-			int pos=hashPos(s+"?" +i);
-			this.addReferences(pos);
-		}
-	}
-	private void addReferences(int pos){
-		onBits.add(pos);
-		
-		HashMap<Integer,Boolean> cAtoms=FPbit.get(pos);
-		if(cAtoms==null){
-			cAtoms= new HashMap<Integer, Boolean>();
-			FPbit.put(pos,cAtoms);
-		}
-		for(Atom a2:atomStack){
-			cAtoms.put(a2.getAtomToAtomMap().orElse(0),true);
-		}
-	}
-	private int hashPos(String s){
-		return Math.abs(s.hashCode()%(nBits));
-	}
-	public static void main(String[] args) throws Exception{
-		
-	}
-	
-	public int getNumberBits() {
-		return this.nBits;
-	}
-	
-	public void setNumberBits(int nBits) {
-		this.nBits=nBits;
-	}
+public class ECFingerprint{
+    private int nBits;
+    private int MAX_LENGTH=8;
+    private int BITS_PER_STRING=1;
+    private boolean encodeWhole=false;
+    private Map<Integer,HashMap<Integer,Boolean>> FPbit = new HashMap<Integer,HashMap<Integer,Boolean>>();
+    private ArrayList<Integer> onBits = new ArrayList<Integer>();
+    private Stack<Atom> atomStack= new Stack<Atom>();
+
+    public ECFingerprint(int nBits, int MAX_LENGTH, int BITS_PER_STRING, boolean encodeWhole){
+        this.nBits=nBits;
+        this.MAX_LENGTH=MAX_LENGTH;
+        this.BITS_PER_STRING=BITS_PER_STRING;
+        this.encodeWhole=encodeWhole;
+    }
+
+    public long[] getFingerprint(Chemical c){
+        return myFingerprint(c,nBits);
+    }
+    private void assignMap(Chemical c){
+        int i=1;
+        for(Atom a:c.getAtoms()){
+            a.setAtomToAtomMap(i);
+            i++;
+        }
+    }
+    private void unAssignMap(Chemical c){
+        for(Atom a:c.getAtoms()){
+            a.setAtomToAtomMap(0);
+        }
+    }
+    private long[] myFingerprint(Chemical c,int nBits){
+        c.makeHydrogensImplicit();
+        FPbit = new HashMap<Integer,HashMap<Integer,Boolean>>();
+        onBits = new ArrayList<Integer>();
+        ArrayList<Atom> atomList = new ArrayList<Atom>();
+        ArrayList<Atom> visitedAtoms = new ArrayList<Atom>();
+        ArrayList<Atom> cRing = new ArrayList<Atom>();
+
+        assignMap(c);
+        for(Atom atom : c.getAtoms()){
+            atomList = new ArrayList<Atom>();
+            visitedAtoms = new ArrayList<Atom>();
+            atomList.add(atom);
+            String desc=atom.getSymbol();
+            int depth=0;
+            this.addDescriptor(desc);
+            while(depth<MAX_LENGTH){
+                visitedAtoms.addAll(atomList);	
+                for(Atom gAtom : atomList){
+                    for(Atom nAtom : gAtom.getNeighbors()){
+                        if(!visitedAtoms.contains(nAtom))
+                            cRing.add(nAtom);
+                    }
+                }
+                if(cRing.size()<=0)break;
+                Collections.sort(cRing, Comparator.comparing(a->asString(a)));
+                desc+="(" +makeSTR(cRing) + ")";
+                atomList=cRing;
+                cRing = new ArrayList<Atom>();	
+                depth++;
+                this.addDescriptor(desc);
+            }	
+        }
+
+        long[] fprints= new long[nBits/64];
+        long sum=0;
+        for(int i:onBits){
+            sum+=i;
+            fprints[i/64]=fprints[i/64]|(1<<i%64);
+        }
+        if(encodeWhole) {
+            int b=fold(sum);
+            fprints[b/64]=fprints[b/64]|(1<<b%64);
+        }
+        unAssignMap(c);
+        return fprints;
+    }
+    private String asString(Atom ca){
+        return ca.getSymbol() + ca.getImplicitHCount();
+    }
+    private String makeSTR(List<Atom> cList){
+        StringBuilder ret=new StringBuilder();
+        for(Atom ca: cList){
+            ret.append(asString(ca));
+        }
+        return ret.toString();
+    }
+    private void addDescriptor(String s){
+        for(int i=0;i<BITS_PER_STRING;i++){
+            int pos=hashPos(s+"?" +i);
+            this.addReferences(pos);
+        }
+    }
+    private void addReferences(int pos){
+        onBits.add(pos);
+
+        HashMap<Integer,Boolean> cAtoms=FPbit.get(pos);
+        if(cAtoms==null){
+            cAtoms= new HashMap<Integer, Boolean>();
+            FPbit.put(pos,cAtoms);
+        }
+        for(Atom a2:atomStack){
+            cAtoms.put(a2.getAtomToAtomMap().orElse(0),true);
+        }
+    }
+    private int hashPos(String s){
+        return fold(s.hashCode());
+    }
+    private int fold(long l) {
+        return (int)Math.abs(l%(nBits));
+    }
 }

--- a/src/main/java/gov/nih/ncats/structureIndexer/ECFingerprinter.java
+++ b/src/main/java/gov/nih/ncats/structureIndexer/ECFingerprinter.java
@@ -9,22 +9,22 @@ import gov.nih.ncats.molwitch.fingerprint.Fingerprinter;
 
 
 public class ECFingerprinter implements Fingerprinter{
-	int nBits;
-	int MAX_LENGTH=8;
-	int BITS_PER_STRING=1;
-	
-	
-	public ECFingerprinter(int nBits, int MAX_LENGTH, int BITS_PER_STRING){
-		this.nBits=nBits;
-		this.MAX_LENGTH=MAX_LENGTH;
-		this.BITS_PER_STRING=BITS_PER_STRING;
-	}
-	
-	@Override
-	public Fingerprint computeFingerprint(Chemical chemical) {
-		ECFingerprint ecf = new ECFingerprint(nBits, MAX_LENGTH, BITS_PER_STRING);
-		
-		long[] fp1=ecf.getFingerprint(chemical);
-		return new Fingerprint(BitSet.valueOf(fp1), nBits);
-	}
+    private int nBits;
+    private int maxLength=8;
+    private int bitsPerString=1;
+    private boolean encodeWhole = true;
+
+    public ECFingerprinter(int nBits, int maxLength, int bitsPerString, boolean encodeWhole){
+        this.nBits=nBits;
+        this.maxLength=maxLength;
+        this.bitsPerString=bitsPerString;
+        this.encodeWhole=encodeWhole;
+    }
+
+    @Override
+    public Fingerprint computeFingerprint(Chemical chemical) {
+        ECFingerprint ecf = new ECFingerprint(nBits, maxLength, bitsPerString, encodeWhole);
+        long[] fp1=ecf.getFingerprint(chemical);
+        return new Fingerprint(BitSet.valueOf(fp1), nBits);
+    }
 }

--- a/src/main/java/gov/nih/ncats/structureIndexer/StructureIndexer.java
+++ b/src/main/java/gov/nih/ncats/structureIndexer/StructureIndexer.java
@@ -821,7 +821,7 @@ public class StructureIndexer {
     												);
     
     private Fingerprinter fingerPrinterSim = new ConcatFingerprinter()
-    		 								.addFP(new ECFingerprinter(512,3,1),512)
+    		 								.addFP(new ECFingerprinter(512,3,1,true),512)
     		 								.addFP(fingerPrinterSub,512)
     		 								.folded(512);
     

--- a/src/test/java/gov/nih/ncats/structureIndexer/Junit4StructureIndexerTest.java
+++ b/src/test/java/gov/nih/ncats/structureIndexer/Junit4StructureIndexerTest.java
@@ -175,6 +175,17 @@ public class Junit4StructureIndexerTest extends AbstractStructureIndexerTest {
         assertEquals("one", result1.getId());
         assertTrue(Double.toString(result1.getSimilarity()), result1.getSimilarity() < 1.00D);
     }
+    
+    @Test
+    public void similaritySearchForVeryCloseLongChainThingsShouldStillBeDifferent() throws Exception {
+        indexer.add("foo", "one", "CCCCCCCCCCCCCCCCCCCOCCCCCCCCCCCCCCCCCC");
+        ResultEnumeration result =
+                indexer.similarity("CCCCCCCCCCCCOCCCCCCCCCCCCCCCCCCCCCCCC", 0.9);
+        assertTrue(result.hasMoreElements());
+        Result result1 = result.nextElement();
+        assertEquals("one", result1.getId());
+        assertTrue(Double.toString(result1.getSimilarity()), result1.getSimilarity() < 1.00D);
+    }
 
     @Test
     public void correctlyFormattedSmilesAromatic() throws Exception {


### PR DESCRIPTION
Adds a single optional bit to similarity fingerprint which encodes all bits turned on, including multiplicity.

This is only added to similarity FP, and has the net effect of penalizing most similarity scores a little bit.

Before (15 vs 16):
```
sim(CCCCCCCCCCCCCCC,CCCCCCCCCCCCCCCC) == 1
```

After (15 vs 16):
```
sim(CCCCCCCCCCCCCCC,CCCCCCCCCCCCCCCC) ~= 0.91
```
